### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Features:
 * There are 2 plugins: SlideShow and Slide. A SlideShow can only contains Slides. Those can be arranged in the order you want just like any other plugin.
 * Each image can have a url specified (creating an anchor around the image)
 * By default, creates a [flexslider](http://www.woothemes.com/flexslider/) slideshow.
+* By default, uses [sorl-thumbnail](https://github.com/mariocesar/sorl-thumbnail) as a thumbnail plugin.
 
 Installation
 ------------
@@ -17,6 +18,7 @@ This plugin requires `django CMS 3.0` or higher to be properly installed and con
 To install:
 
 * run `pip install djangocms-slider` on your virtualenv
+* add `sorl.thumbnail` to your `INSTALLED_APPS` setting if you want to use default template.
 * add `djangocms_slider` to your `INSTALLED_APPS` setting (mind the underscore)
 * Run `./manage.py migrate djangocms_slider`
 


### PR DESCRIPTION
By default, templates use sorl-thumbnail as a thumbnail plugin. You may have issues after installing djangocms-slider if you don't add it in INSTALLED_APPS.
