### PR TITLE
Remove dependency in initial migration

### DIFF
--- a/djangocms_slider/migrations/0001_initial.py
+++ b/djangocms_slider/migrations/0001_initial.py
@@ -8,7 +8,6 @@ import cms.models.pluginmodel
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('cms', '__latest__'),
     ]
 
     operations = [


### PR DESCRIPTION
Remove dependency `('cms', '__latest__')` in `migrations/0001_initial.py` because it leads to an exception: django.db.migrations.exceptions.InconsistentMigrationHistory when there are new Django CMS migrations, which are then a dependency of the already executed initial slider migration.